### PR TITLE
fix for issue reported in Karate tests

### DIFF
--- a/src/main/java/uk/gov/companieshouse/customerfeedbackapi/service/CustomerFeedbackService.java
+++ b/src/main/java/uk/gov/companieshouse/customerfeedbackapi/service/CustomerFeedbackService.java
@@ -55,7 +55,9 @@ public class CustomerFeedbackService {
 
     customerFeedbackDAO.setCreatedAt(LocalDateTime.now());
 
-    boolean emailSent = emailSendFlag && !customerFeedbackDAO.getData().getSourceUrl().isBlank();
+    String sourceUrl = customerFeedbackDAO.getData().getSourceUrl();
+
+    boolean emailSent = emailSendFlag && sourceUrl != null && !sourceUrl.isBlank();
     customerFeedbackDAO.setEmailSent(emailSent);
 
     ApiLogger.debugContext(requestId, "Inserting customer feedback record");

--- a/src/test/java/uk/gov/companieshouse/customerfeedbackapi/unit/service/CustomerFeedbackServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/customerfeedbackapi/unit/service/CustomerFeedbackServiceTest.java
@@ -90,4 +90,22 @@ class CustomerFeedbackServiceTest {
     }
   }
 
+  @Test
+  void testCreateCustomerFeedbackDoesNotSendEmailWhenSourceUrlIsNull() throws Exception {
+    CustomerFeedbackDTO dtoWithNullSourceUrl =
+            helper.generateCustomerFeedbackDTO(EMAIL, FEEDBACK, NAME, KIND, null);
+    CustomerFeedbackDAO daoWithNullSourceUrl =
+            helper.generateCustomerFeedbackDAO(EMAIL, FEEDBACK, NAME, KIND, null, CREATED_AT, false);
+
+    when(customerFeedbackMapper.dtoToDao(any())).thenReturn(daoWithNullSourceUrl);
+    when(customerFeedbackRepository.insert(daoWithNullSourceUrl)).thenReturn(daoWithNullSourceUrl);
+
+    ReflectionTestUtils.setField(customerFeedbackService, "emailSendFlag", true);
+
+    // Should not throw NullPointerException
+    customerFeedbackService.createCustomerFeedback(dtoWithNullSourceUrl, REQUEST_ID);
+
+    verify(customerFeedbackRepository, times(1)).insert(daoWithNullSourceUrl);
+  }
+
 }


### PR DESCRIPTION
Link to. issue -> https://companieshouse.atlassian.net/browse/ASM-2259?focusedCommentId=366067

Prevent a NullPointerException when the optional `source_url` field is omitted from customer feedback requests.